### PR TITLE
[HGNN-9092] 스플래시 IOS 광고 종료하였으나 데이터가 집계되는 이슈

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,46 +1,46 @@
 {
-  "name": "cordova-plugin-splashscreen",
-  "version": "6.0.0-hogangnono",
-  "description": "Cordova Splashscreen Plugin",
-  "types": "./types/index.d.ts",
-  "cordova": {
-    "id": "cordova-plugin-splashscreen",
-    "platforms": [
-      "android",
-      "ios"
-    ]
-  },
-  "repository": "github:apache/cordova-plugin-splashscreen",
-  "bugs": "https://github.com/apache/cordova-plugin-splashscreen/issues",
-  "keywords": [
-    "cordova",
-    "splashscreen",
-    "ecosystem:cordova",
-    "cordova-android",
-    "cordova-ios"
-  ],
-  "scripts": {
-    "test": "npm run jshint",
-    "jshint": "node node_modules/jshint/bin/jshint www && node node_modules/jshint/bin/jshint src && node node_modules/jshint/bin/jshint tests"
-  },
-  "engines": {
-    "cordovaDependencies": {
-      "2.0.0": {
-        "cordova-android": ">=3.6.0"
-      },
-      "4.0.0": {
-        "cordova-android": ">=3.6.0"
-      },
-      "6.0.0": {
-        "cordova": ">100"
-      }
+    "name": "cordova-plugin-splashscreen",
+    "version": "6.0.1-hogangnono",
+    "description": "Cordova Splashscreen Plugin",
+    "types": "./types/index.d.ts",
+    "cordova": {
+        "id": "cordova-plugin-splashscreen",
+        "platforms": [
+            "android",
+            "ios"
+        ]
     },
-    "node": ">=6.0.0"
-  },
-  "author": "Apache Software Foundation",
-  "license": "Apache-2.0",
-  "devDependencies": {
-    "jshint": "^2.6.0"
-  },
-  "homepage": "https://cordova.apache.org/"
+    "repository": "github:apache/cordova-plugin-splashscreen",
+    "bugs": "https://github.com/apache/cordova-plugin-splashscreen/issues",
+    "keywords": [
+        "cordova",
+        "splashscreen",
+        "ecosystem:cordova",
+        "cordova-android",
+        "cordova-ios"
+    ],
+    "scripts": {
+        "test": "npm run jshint",
+        "jshint": "node node_modules/jshint/bin/jshint www && node node_modules/jshint/bin/jshint src && node node_modules/jshint/bin/jshint tests"
+    },
+    "engines": {
+        "cordovaDependencies": {
+            "2.0.0": {
+                "cordova-android": ">=3.6.0"
+            },
+            "4.0.0": {
+                "cordova-android": ">=3.6.0"
+            },
+            "6.0.0": {
+                "cordova": ">100"
+            }
+        },
+        "node": ">=6.0.0"
+    },
+    "author": "Apache Software Foundation",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "jshint": "^2.6.0"
+    },
+    "homepage": "https://cordova.apache.org/"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-splashscreen"
-      version="6.0.0-hogangnono">
+      version="6.0.1-hogangnono">
     <name>Splashscreen</name>
     <description>Cordova Splashscreen Plugin</description>
     <license>Apache 2.0</license>

--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -94,7 +94,8 @@
         [result setObject:id forKey:@"id"];
     }
     if (isAdDisplayed != nil) {
-        [result setObject:[NSNumber numberWithBool:isAdDisplayed] forKey:@"isAdDisplayed"];
+        BOOL isAdDisplayedBool = [isAdDisplayed boolValue];  // NSString을 BOOL로 변환
+        [result setObject:[NSNumber numberWithBool:isAdDisplayedBool] forKey:@"isAdDisplayed"];
     }
     
     

--- a/src/ios/CDVSplashScreenADLoader.m
+++ b/src/ios/CDVSplashScreenADLoader.m
@@ -89,6 +89,10 @@
     [defaults removeObjectForKey:@"SplashUpdatedAt"];
     [defaults removeObjectForKey:@"SplashBegin"];
     [defaults removeObjectForKey:@"SplashEnd"];
+
+    [defaults removeObjectForKey:@"displayedSplashId"];
+    [defaults removeObjectForKey:@"isAdDisplayed"];    
+    
     [defaults synchronize]; // 변경사항 적용
 
     // 문서 디렉토리 경로 구하기


### PR DESCRIPTION
<!--
- PR 제목은 단순 브랜치명이 아닌 작업내용의 대표문구 또는 이슈 제목이 들어가야합니다.
- 필수항목(*) 기재하지 않았을 경우, approve/merge 불가합니다.
- 주석은 내용 숙지 후 제거해도 무방합니다.
-->

# 관련 이슈*
- https://zigbang.atlassian.net/browse/HGNN-9092

# 작업 내용*
-  isAdDisplayed 형변환하여 result에 셋팅
 - navigator.splashscreen.removeAd() 호출시 displayedSplashId, isAdDisplayed 제거

# 체크리스트*
<!-- 확인해야할 사항을 정리하고 확인해주세요. -->

- [x] PR 모든 항목을 빠짐없이 작성했습니다. (제목, 담당자, 라벨, 마일스톤 등)
- [x] m/www/app 환경에서 각각 테스트하였습니다.

# 기타
<!-- 기타 공유할 사항이 있다면 설명해주세요. -->

없음
