### PR TITLE
[HGNN-10913][Android] 초기 앱 배경색을 스플래시와 맞춤

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-splashscreen",
-  "version": "6.0.4-hogangnono",
+"version": "6.1.0-hogangnono",
   "description": "Cordova Splashscreen Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-splashscreen"
-      version="6.0.4-hogangnono">
+      version="6.1.0-hogangnono">
     <name>Splashscreen</name>
     <description>Cordova Splashscreen Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/themes.xml
+++ b/src/android/themes.xml
@@ -1,5 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
+    <style name="Theme.App.SplashBackground" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowBackground">@color/cdv_splashscreen_background</item>
+    </style>
 	<style name="Theme.Custom.Splash" parent="Theme.AppCompat.NoActionBar">
         <item name="colorPrimary">@color/cdv_splashscreen_background</item>
         <item name="colorPrimaryDark">@color/cdv_splashscreen_background</item>
@@ -7,5 +10,6 @@
     </style>
     <style name="Theme.Remove.Splash" parent="@style/Theme.App.SplashScreen">
         <item name="android:windowIsTranslucent">true</item>
+        <item name="postSplashScreenTheme">@style/Theme.App.SplashBackground</item>
     </style>
 </resources>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

앱을 초기에 여러번 실행시켜 핫스타트인경우 잠깐 회색 화면이 표시됨

https://zigbang.slack.com/archives/C094S8NL9MG/p1755563543556729?thread_ts=1755497486.014549&cid=C094S8NL9MG


### Description
<!-- Describe your changes in detail -->

초기 앱 화면 배경색을 스플래시 배경색과 맞춤

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
